### PR TITLE
lisp 😎😎😎😎😎😎

### DIFF
--- a/MatrixMultiplication_Common_Lisp/mmul.lisp
+++ b/MatrixMultiplication_Common_Lisp/mmul.lisp
@@ -1,0 +1,32 @@
+; # Run
+; sbcl --load mmul.lisp
+
+(defmacro mref (matrix row col)
+    `(aref (cadr ,matrix) (+ ,col (* ,row (cdar ,matrix)))))
+
+(defun make-matrix (rows cols &optional &key (initial-element 0.0))
+    `((,rows . ,cols)
+      ,(make-array (* cols rows) :initial-element initial-element :element-type 'float)))
+
+(defun randomize-matrix (m)
+    `(,(car m)
+      ,(map 'vector (lambda (x) (random 100.0)) (cadr m))))
+
+(defun mmul (a b)
+    (let* ((rows (caar a))
+           (cols (cdar b))
+           (b-rows (caar b))
+           (result (make-matrix rows cols))
+           (temp-sum 0.0))
+        (dotimes (row rows)
+            (dotimes (col cols)
+                (setq temp-sum 0.0)
+                (dotimes (i b-rows)
+                    (setq temp-sum (+ temp-sum (* (mref a row i) (mref b i col))))
+                (setf (mref result row col) temp-sum))))
+        result))
+
+(defvar *a* (randomize-matrix (make-matrix 1440 1440)))
+(defvar *b* (randomize-matrix (make-matrix 1440 1440)))
+
+(time (mmul *a* *b*))


### PR DESCRIPTION
# Ausführen
sbcl --load mmul.lisp
(Mit [sbcl](http://www.sbcl.org/) für speeeed)

# Ergebnis (i5-2520M)
```
 Evaluation took:
171.613 seconds of real time
171.450172 seconds of total run time (171.449789 user, 0.000383 system)
99.91% CPU
427,646,048,310 processor cycles
16,588,816 bytes consed
```